### PR TITLE
Fix Issue with Lightbox option and Form Block

### DIFF
--- a/packages/are_you_a_human/CHANGELOG
+++ b/packages/are_you_a_human/CHANGELOG
@@ -1,0 +1,2 @@
+1.0.1
+	- Fixed issue with Lightbox and Form Block unable to submit

--- a/packages/are_you_a_human/controller.php
+++ b/packages/are_you_a_human/controller.php
@@ -5,7 +5,7 @@ class AreYouAHumanPackage extends Package {
 
 	protected $pkgHandle = "are_you_a_human";
 	protected $appVersionRequired = "5.5";
-	protected $pkgVersion = "0.9.2";
+	protected $pkgVersion = "1.0.1";
 
 	public function getPackageName() {
 		return t('Are You A Human');

--- a/packages/are_you_a_human/models/system/captcha/types/are_you_a_human/controller.php
+++ b/packages/are_you_a_human/models/system/captcha/types/are_you_a_human/controller.php
@@ -22,6 +22,11 @@ class AreYouAHumanSystemCaptchaTypeController extends SystemCaptchaTypeControlle
 	}
 
 	public function display() {
+		$page = Page::getCurrentPage();
+		if (is_object($page) && $page->isEditMode()) {
+			echo '<div class="ccm-edit-mode-disabled-item" style="width: 360px; height: 50px"><div style="margin: 15px auto;">' . t('Captcha is disabled in edit mode.') . '</div></div>';
+			return;
+		}
 		echo $this->ayah->getPublisherHTML();
 	}
 


### PR DESCRIPTION
Fix issue with lightbox option set in Are You A Human site dashboard.

Lightbox option would pop up when trying to save form block and
prevented form block from saving.
- Disable display of captcha in edit mode
